### PR TITLE
Cleaned up INITIAL_EXTENSIONS

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -18,7 +18,6 @@ INITIAL_EXTENSIONS = [
     'cogs.ping',
     'cogs.tags',
     'cogs.automod',
-    'cogs.bio',
     'cogs.stats',
     'cogs.stattrak',
     'cogs.meta',
@@ -31,8 +30,6 @@ INITIAL_EXTENSIONS = [
     'cogs.nsfw',
     'cogs.reminders',
     'cogs.roles',
-    'cogs.stars',
-    'cogs.wolfram'
 ]
 
 


### PR DESCRIPTION
I removed those cogs that are neither in .gitignore or cogs. They just lead to errormessages on loading and are therefor useless. @CarlGroth please review and maybe also think about adding an explanation about 
cogs/utils/
cogs/admin.py
cogs/reminders.py
cogs/convert.py
cogs/nsfw.py
that are still in gitignore (so others know that these errors are normal)